### PR TITLE
Change data type of entity_id to allow for more than ~65K records to be inserted

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -21,7 +21,7 @@
     </table>
 
     <table name="mulberry_warranty_queue" resource="sales" engine="innodb" comment="Mulberry Warranty Processing Queue">
-        <column xsi:type="smallint" name="entity_id" padding="6" unsigned="true" nullable="false" identity="true" comment="Entity Id"/>
+        <column xsi:type="int" name="entity_id" padding="10" unsigned="true" nullable="false" identity="true" comment="Entity Id"/>
         <column xsi:type="int" name="order_id" padding="10" unsigned="true" nullable="false" identity="false" comment="Order Id"/>
         <column xsi:type="varchar" name="action_type" nullable="true" length="32" comment="Export Action Type"/>
         <column xsi:type="varchar" name="sync_status" nullable="true" length="32" comment="Mulberry Order Sync Status"/>


### PR DESCRIPTION
The old value caused an issue during order placement on a Magento site after 65535 records had been inserted into this table.

```
Could not save the queue: SQLSTATE[22003]: Numeric value out of range: 167 Out of range value for column 'entity_id' at row 1, query was: INSERT INTO `mulberry_warranty_queue` (`order_id`, `action_type`) VALUES (?, ?)  
```